### PR TITLE
Updating pull_outputs.py command

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ cd $WORKING_BASE
 mkdir final_results
 cd final_results
 
-python3 /opt/scripts/pull_outputs.py --outputs-file=$GCS_BUCKET_PATH/workflow_artifacts/$WORKFLOW_ID/artifacts/outputs.json --outputs-dir=$WORKING_BASE/final_results/
+python3 /opt/scripts/pull_outputs.py --outputs-file=$GCS_BUCKET_PATH/workflow_artifacts/$WORKFLOW_ID/outputs.json --outputs-dir=$WORKING_BASE/final_results/
 exit #leave the docker session
 ```
 


### PR DESCRIPTION
The outputs.json file for both my recent runs was in the $WORKFLOW_ID directory as opposed to the $WORKFLOW_ID/artifacts/ directory.