### PR TITLE
Update pull_outputs.py command to allow for inconsistent artifacts folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ mkdir final_results
 cd final_results
 
 python3 /opt/scripts/pull_outputs.py --outputs-file=$GCS_BUCKET_PATH/workflow_artifacts/$WORKFLOW_ID/artifacts/outputs.json --outputs-dir=$WORKING_BASE/final_results/
+#Sometimes the command above doesn't work, in that case use the command below instead-
+#python3 /opt/scripts/pull_outputs.py --outputs-file=$GCS_BUCKET_PATH/workflow_artifacts/$WORKFLOW_ID/outputs.json --outputs-dir=$WORKING_BASE/final_results/
 exit #leave the docker session
 ```
 


### PR DESCRIPTION
The artifacts directory is created inconsistently and we haven't been able to figure out when it is made vs when it isn't. Suggest the readme has both commands handy.